### PR TITLE
<span> and popup=1 removed from prosearch title

### DIFF
--- a/assets/ProSearch.js
+++ b/assets/ProSearch.js
@@ -355,3 +355,62 @@
     });
 
 })();
+
+/**
+ * this is an extension to hide buttons in the modal window
+ *
+ * @type {{openModalIframe: GZM.openModalIframe}}
+ */
+var GZM =
+{
+    /**
+     * Open an iframe in a modal window
+     *
+     * @param {object} options An optional options object
+     */
+    openModalIframe: function(options) {
+        var opt = options || {},
+            maxWidth = (window.getSize().x - 20).toInt(),
+            maxHeight = (window.getSize().y - 137).toInt();
+        if (!opt.width || opt.width > maxWidth) opt.width = Math.min(maxWidth, 900);
+        if (!opt.height || opt.height > maxHeight) opt.height = maxHeight;
+
+        var M = new SimpleModal({
+            'width': opt.width,
+            'hideFooter': true,
+            'draggable': false,
+            'overlayOpacity': .7,
+            'onShow': function() {
+                document.body.setStyle('overflow', 'hidden');
+
+                // wait a little until the iframe is initialized
+                setTimeout(function()
+                {
+                    let iframe = document.querySelector('iframe');
+
+                    if(iframe)
+                    {
+                        iframe.addEventListener("load", function ()
+                        {
+                            let submitContainer = iframe.contentWindow.document.querySelector('div .tl_submit_container');
+
+                            if (submitContainer)
+                            {
+                                let splitButton = submitContainer.querySelector('div.split-button');
+
+                                if (splitButton) splitButton.remove();
+                            }
+                        });
+                    }
+                }, 100)
+            },
+            'onHide': function() { document.body.setStyle('overflow', 'auto'); }
+        });
+
+        M.show({
+            'title': opt.title,
+            'contents': '<iframe src="' + opt.url + '" width="100%" height="' + opt.height + '" frameborder="0"></iframe>',
+            'model': 'modal'
+        });
+    },
+}

--- a/assets/ProSearch.js
+++ b/assets/ProSearch.js
@@ -96,10 +96,10 @@
         
         //ie add origin 9
         if (!window.location.origin) {
-	        
-			window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
-			
-		}
+            
+            window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+            
+        }
         
         // get search data from search index
         var host = window.location.origin;
@@ -173,10 +173,10 @@
         var $template =
             '<div class="<%= cssClass %> <%= n %>">' +
                 '<div class="category-results">'+
-                	'<%= buttonsStr %>'+
+                    '<%= buttonsStr %>'+
                 '</div>'+
             '</div>';
-		
+        
         var render = _.template($template);
 
         return render(item);
@@ -190,7 +190,7 @@
      */
     function ItemsView(data)
     {
-	    	 
+             
         var options = {
             count: data.length
         };
@@ -203,8 +203,8 @@
 
             var category_label = shortcut_labels[category];
 
-	        $template += ItemsCategory(item, category_label);
-	        
+            $template += ItemsCategory(item, category_label);
+            
         });
 
         $template += endWrapper;
@@ -215,18 +215,18 @@
     }
     
     /**
-	 *
-	 */   
+     *
+     */   
     function ItemsCategory(item, category)
     {
-	    
-	    var $template = '';
+        
+        var $template = '';
 
-	    $template += '<div class="result-category"><div class="result-category-header"><%= category %></div>';
-	    
-	    _.each(item, function(row, i){
-							
-			row['n'] = i % 2 ? 'even' : 'odd';
+        $template += '<div class="result-category"><div class="result-category-header"><%= category %></div>';
+        
+        _.each(item, function(row, i){
+                            
+            row['n'] = i % 2 ? 'even' : 'odd';
             row['cssClass'] = 'result';
 
             if(i == 0)
@@ -240,22 +240,22 @@
             }
 
             $template += ItemView(row);
-		
-		});
-	    
-	    $template += '</div>';	  
-	    
-	    var render = _.template($template);
-	    var obj = {
-		    category: category
-	    };
+        
+        });
+        
+        $template += '</div>';      
+        
+        var render = _.template($template);
+        var obj = {
+            category: category
+        };
         return render(obj);
         
     }
 
     window.addEvent('domready', function() {
 
-	    var strHeaderTemplate = strProSearchHeaderTemplate ? strProSearchHeaderTemplate : '';
+        var strHeaderTemplate = strProSearchHeaderTemplate ? strProSearchHeaderTemplate : '';
         var _userSettings = UserSettings ? UserSettings : {};
         var shortcut = _userSettings.shortcut ? _userSettings.shortcut : 'alt+m';
 
@@ -320,97 +320,38 @@
             strHeaderTemplate = '';
         }
 
-	    // remove menu by escape key
-	    document.addEvent('keydown:keys(esc)', function(e){
-	
-	        e.preventDefault();
-			
-			var body = $$('body');
-			body.toggleClass('searchMenuActive');
-			
-	        // remove search
-	        if(!body.hasClass('searchMenuActive')[0])
-	        {		       
-		        var menu = document.getElementById("id_menu-overlay");
+        // remove menu by escape key
+        document.addEvent('keydown:keys(esc)', function(e){
+    
+            e.preventDefault();
+            
+            var body = $$('body');
+            body.toggleClass('searchMenuActive');
+            
+            // remove search
+            if(!body.hasClass('searchMenuActive')[0])
+            {               
+                var menu = document.getElementById("id_menu-overlay");
 
                 $$(document).removeEvent('keydown:keys(down)');
                 $$(document).removeEvent('keydown:keys(up)');
                 tabIndex = -1;
 
                 $(menu).destroy();
-	        }
-	        
-	
-	    });
-	    
-	    //add header btn
-	    var header = $$('#tmenu');
+            }
+            
+    
+        });
+        
+        //add header btn
+        var header = $$('#tmenu');
         header.appendHTML( strHeaderTemplate, 'top' );
         
         $$('#openProSearch').addEvent('click', function(e){
-	    	e.preventDefault();
-	        document.fireEvent('keydown:keys('+shortcut+')', e);    
+            e.preventDefault();
+            document.fireEvent('keydown:keys('+shortcut+')', e);    
         });
         
     });
 
 })();
-
-/**
- * this is an extension to hide buttons in the modal window
- *
- * @type {{openModalIframe: GZM.openModalIframe}}
- */
-var GZM =
-{
-    /**
-     * Open an iframe in a modal window
-     *
-     * @param {object} options An optional options object
-     */
-    openModalIframe: function(options) {
-        var opt = options || {},
-            maxWidth = (window.getSize().x - 20).toInt(),
-            maxHeight = (window.getSize().y - 137).toInt();
-        if (!opt.width || opt.width > maxWidth) opt.width = Math.min(maxWidth, 900);
-        if (!opt.height || opt.height > maxHeight) opt.height = maxHeight;
-
-        var M = new SimpleModal({
-            'width': opt.width,
-            'hideFooter': true,
-            'draggable': false,
-            'overlayOpacity': .7,
-            'onShow': function() {
-                document.body.setStyle('overflow', 'hidden');
-
-                // wait a little until the iframe is initialized
-                setTimeout(function()
-                {
-                    let iframe = document.querySelector('iframe');
-
-                    if(iframe)
-                    {
-                        iframe.addEventListener("load", function ()
-                        {
-                            let submitContainer = iframe.contentWindow.document.querySelector('div .tl_submit_container');
-
-                            if (submitContainer)
-                            {
-                                let splitButton = submitContainer.querySelector('div.split-button');
-
-                                if (splitButton) splitButton.remove();
-                            }
-                        });
-                    }
-                }, 100)
-            },
-            'onHide': function() { document.body.setStyle('overflow', 'auto'); }
-        });
-
-        M.show({
-            'title': opt.title,
-            'contents': '<iframe src="' + opt.url + '" width="100%" height="' + opt.height + '" frameborder="0"></iframe>',
-            'model': 'modal'
-        });
-    },
-}

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,9 @@
 	"require": {
 		"php": ">=5.4",
 		"contao/core-bundle": "~3.5 || ~4.1",
-		"contao-community-alliance/composer-plugin": "~2.4 || ~3.0"
-	},
+		"contao-community-alliance/composer-plugin": "~2.4 || ~3.0",
+      	"ext-json": "*"
+    },
 	"require-dev": {
 		"contao/easy-coding-standard": "^3.0",
 		"phpunit/phpunit": "^8.5 || ^9.5",

--- a/composer.json
+++ b/composer.json
@@ -1,61 +1,61 @@
 {
-	"name": "pdir/prosearch",
-	"description": "ProSearch - Backend search for Contao CMS",
-	"keywords": [ "contao", "backend", "search", "filter", "tags" ],
-	"type": "contao-module",
-	"homepage": "http://backend-suche-contao.alexandernaumov.de",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Alexander Naumov",
-			"homepage": "https://www.alexandernaumov.de",
-			"role": "Developer"
-		}
-	],
-	"require": {
-		"php": ">=5.4",
-		"contao/core-bundle": "~3.5 || ~4.1",
-		"contao-community-alliance/composer-plugin": "~2.4 || ~3.0",
-      	"ext-json": "*"
+    "name": "pdir/prosearch",
+    "description": "ProSearch - Backend search for Contao CMS",
+    "keywords": [ "contao", "backend", "search", "filter", "tags" ],
+    "type": "contao-module",
+    "homepage": "http://backend-suche-contao.alexandernaumov.de",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Alexander Naumov",
+            "homepage": "https://www.alexandernaumov.de",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": ">=5.4",
+        "contao/core-bundle": "~3.5 || ~4.1",
+        "contao-community-alliance/composer-plugin": "~2.4 || ~3.0",
+          "ext-json": "*"
     },
-	"require-dev": {
-		"contao/easy-coding-standard": "^3.0",
-		"phpunit/phpunit": "^8.5 || ^9.5",
-		"symfony/phpunit-bridge": "^5.3 || ^6.0"
-	},
-	"support": {
-		"email": "me@alexandernaumov.de",
-		"issues": "https://github.com/alnv/prosearch/issues",
-		"wiki": "https://backend-suche-contao.alexandernaumov.de/fuer-redakteure.html"
-	},
-	"scripts": {
-		"all": [
-			"@cs-fixer",
-			"@phpunit"
-		],
-		"cs-fixer": "@php vendor/bin/ecs check src/ --fix --ansi",
-		"phpunit": "@php vendor\\bin\\phpunit --configuration phpunit.xml --coverage-text --log-junit report.xml"
-	},
-	"autoload": {
-		"classmap": [
-			"src/"
-		]
-	},
-	"replace": {
-		"contao-legacy/prosearch": "self.version"
-	},
-	"extra": {
-		"contao": {
-			"sources": {
-				"": "system/modules/prosearch"
-			}
-		}
-	},
-	"config": {
-		"allow-plugins": {
-			"contao-components/installer": true,
-			"contao-community-alliance/composer-plugin": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
-	}
+    "require-dev": {
+        "contao/easy-coding-standard": "^3.0",
+        "phpunit/phpunit": "^8.5 || ^9.5",
+        "symfony/phpunit-bridge": "^5.3 || ^6.0"
+    },
+    "support": {
+        "email": "me@alexandernaumov.de",
+        "issues": "https://github.com/alnv/prosearch/issues",
+        "wiki": "https://backend-suche-contao.alexandernaumov.de/fuer-redakteure.html"
+    },
+    "scripts": {
+        "all": [
+            "@cs-fixer",
+            "@phpunit"
+        ],
+        "cs-fixer": "@php vendor/bin/ecs check src/ --fix --ansi",
+        "phpunit": "@php vendor\\bin\\phpunit --configuration phpunit.xml --coverage-text --log-junit report.xml"
+    },
+    "autoload": {
+        "classmap": [
+            "src/"
+        ]
+    },
+    "replace": {
+        "contao-legacy/prosearch": "self.version"
+    },
+    "extra": {
+        "contao": {
+            "sources": {
+                "": "system/modules/prosearch"
+            }
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "contao-components/installer": true,
+            "contao-community-alliance/composer-plugin": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
 }

--- a/dca/tl_prosearch_settings.php
+++ b/dca/tl_prosearch_settings.php
@@ -22,28 +22,30 @@ $GLOBALS['TL_DCA']['tl_prosearch_settings'] = array(
     ),
 
     // Palettes
-    'palettes' => array
-    (
-        'default' => '{settings_legend},searchIndexModules,addDescriptionToSearchContent,createIndex'
-    ),
+    'palettes' => [
+        'default' => '{settings_legend},searchIndexModules,addDescriptionToSearchContent,preventOpenSearchListAsPopup,createIndex'
+    ],
 
     // Fields
     'fields' => array
     (
-        'searchIndexModules' => array
-        (
+        'searchIndexModules' => [
             'label' => &$GLOBALS['TL_LANG']['tl_prosearch_settings']['searchIndexModules'],
             'inputType' => 'checkbox',
-            'options_callback' => array('ProSearch', 'loadModules'),
-            'eval' => array('multiple' => true),
+            'options_callback' => ['ProSearch', 'loadModules'],
+            'eval' => ['multiple' => true],
             'sql' => "blob NULL"
-        ),
+        ],
 
         'addDescriptionToSearchContent' => array(
-
             'label' => &$GLOBALS['TL_LANG']['tl_prosearch_settings']['addDescriptionToSearchContent'],
             'inputType' => 'checkbox',
         ),
+
+        'preventOpenSearchListAsPopup' => [
+            'label' => &$GLOBALS['TL_LANG']['tl_prosearch_settings']['preventOpenSearchListAsPopup'],
+            'inputType' => 'checkbox',
+        ],
 
         'createIndex' => array(
             'label' => &$GLOBALS['TL_LANG']['tl_prosearch_settings']['createIndex'],
@@ -110,16 +112,15 @@ class tl_prosearch_settings extends ProSearch
                     echo json_encode($data);
                     exit;
 
-                }else{
-
+                }
+                else
+                {
                     $data = array('state' => 'success', 'table' => $tableToIndex, 'page' => $pageNum, 'left' => 0);
                     header('Content-type: application/json');
                     echo json_encode($data);
                     exit;
 
                 }
-
-
             }
 
             if( $count < $limit )

--- a/dca/tl_prosearch_settings.php
+++ b/dca/tl_prosearch_settings.php
@@ -23,7 +23,7 @@ $GLOBALS['TL_DCA']['tl_prosearch_settings'] = array(
 
     // Palettes
     'palettes' => [
-        'default' => '{settings_legend},searchIndexModules,addDescriptionToSearchContent,preventOpenSearchListAsPopup,createIndex'
+        'default' => '{settings_legend},searchIndexModules,addDescriptionToSearchContent,createIndex'
     ],
 
     // Fields
@@ -41,11 +41,6 @@ $GLOBALS['TL_DCA']['tl_prosearch_settings'] = array(
             'label' => &$GLOBALS['TL_LANG']['tl_prosearch_settings']['addDescriptionToSearchContent'],
             'inputType' => 'checkbox',
         ),
-
-        'preventOpenSearchListAsPopup' => [
-            'label' => &$GLOBALS['TL_LANG']['tl_prosearch_settings']['preventOpenSearchListAsPopup'],
-            'inputType' => 'checkbox',
-        ],
 
         'createIndex' => array(
             'label' => &$GLOBALS['TL_LANG']['tl_prosearch_settings']['createIndex'],

--- a/dca/tl_user.php
+++ b/dca/tl_user.php
@@ -1,11 +1,11 @@
 <?php
 
-$GLOBALS['TL_DCA']['tl_user']['palettes']['login'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut;', $GLOBALS['TL_DCA']['tl_user']['palettes']['login']);
-$GLOBALS['TL_DCA']['tl_user']['palettes']['admin'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut;', $GLOBALS['TL_DCA']['tl_user']['palettes']['admin']);
-$GLOBALS['TL_DCA']['tl_user']['palettes']['default'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut;', $GLOBALS['TL_DCA']['tl_user']['palettes']['default']);
-$GLOBALS['TL_DCA']['tl_user']['palettes']['group'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut;', $GLOBALS['TL_DCA']['tl_user']['palettes']['group']);
-$GLOBALS['TL_DCA']['tl_user']['palettes']['extend'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut;', $GLOBALS['TL_DCA']['tl_user']['palettes']['extend']);
-$GLOBALS['TL_DCA']['tl_user']['palettes']['custom'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut;', $GLOBALS['TL_DCA']['tl_user']['palettes']['custom']);
+$GLOBALS['TL_DCA']['tl_user']['palettes']['login'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut,preventOpenSearchListAsPopup;', $GLOBALS['TL_DCA']['tl_user']['palettes']['login']);
+$GLOBALS['TL_DCA']['tl_user']['palettes']['admin'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut,preventOpenSearchListAsPopup;', $GLOBALS['TL_DCA']['tl_user']['palettes']['admin']);
+$GLOBALS['TL_DCA']['tl_user']['palettes']['default'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut,preventOpenSearchListAsPopup;', $GLOBALS['TL_DCA']['tl_user']['palettes']['default']);
+$GLOBALS['TL_DCA']['tl_user']['palettes']['group'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut,preventOpenSearchListAsPopup;', $GLOBALS['TL_DCA']['tl_user']['palettes']['group']);
+$GLOBALS['TL_DCA']['tl_user']['palettes']['extend'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut,preventOpenSearchListAsPopup;', $GLOBALS['TL_DCA']['tl_user']['palettes']['extend']);
+$GLOBALS['TL_DCA']['tl_user']['palettes']['custom'] = str_replace('password;', 'password;{prosearch_user_legend:hide},keyboard_shortcut,preventOpenSearchListAsPopup;', $GLOBALS['TL_DCA']['tl_user']['palettes']['custom']);
 
 $GLOBALS['TL_DCA']['tl_user']['fields']['keyboard_shortcut'] = [
 
@@ -21,4 +21,9 @@ $GLOBALS['TL_DCA']['tl_user']['fields']['keyboard_shortcut'] = [
     'explanation' => 'keyboard_shortcut',
     'exclude' => true,
     'sql' => "varchar(12) NOT NULL default ''"
+];
+
+$GLOBALS['TL_DCA']['tl_user']['fields']['preventOpenSearchListAsPopup'] = [
+    'label' => &$GLOBALS['TL_LANG']['tl_user']['preventOpenSearchListAsPopup'],
+    'inputType' => 'checkbox',
 ];

--- a/dca/tl_user.php
+++ b/dca/tl_user.php
@@ -26,6 +26,6 @@ $GLOBALS['TL_DCA']['tl_user']['fields']['keyboard_shortcut'] = [
 $GLOBALS['TL_DCA']['tl_user']['fields']['preventOpenSearchListAsPopup'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_user']['preventOpenSearchListAsPopup'],
     'inputType' => 'checkbox',
-    'eval' => ['tl_class' => 'w50 cbx'],
+    'eval' => ['tl_class' => 'w50 m12 cbx'],
     'sql' => "char(1) NOT NULL default ''"
 ];

--- a/dca/tl_user.php
+++ b/dca/tl_user.php
@@ -26,4 +26,6 @@ $GLOBALS['TL_DCA']['tl_user']['fields']['keyboard_shortcut'] = [
 $GLOBALS['TL_DCA']['tl_user']['fields']['preventOpenSearchListAsPopup'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_user']['preventOpenSearchListAsPopup'],
     'inputType' => 'checkbox',
+    'eval' => ['tl_class' => 'w50 cbx'],
+    'sql' => "char(1) NOT NULL default ''"
 ];

--- a/languages/de/tl_prosearch_settings.php
+++ b/languages/de/tl_prosearch_settings.php
@@ -15,10 +15,6 @@ $GLOBALS['TL_LANG']['tl_prosearch_settings']['prosearchLicense'] = [
     'Lizenzschlüssel eingeben',
     'Lizenzschlüssel <a href="#" target="_blank"><strong>kaufen</strong></a>'
 ];
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['preventOpenSearchListAsPopup'] = [
-    'Links im Ergebnisfenster nicht als Popup öffnen',
-    'Standardmäßig werden die Links aus der Ergebnisliste bei Klick in einem Popup-Window geöffnet. Wird diese Option aktiviert, dann wird der Link in der Standard-Edit-Ansicht geöffnet.'
-];
 $GLOBALS['TL_LANG']['tl_prosearch_settings']['addDescriptionToSearchContent'] = [
     'Texte in die Suche aufnehmen',
     'Diese Option kann die Suche verlangsamen, dafür werden Text Spalten indiziert.'

--- a/languages/de/tl_prosearch_settings.php
+++ b/languages/de/tl_prosearch_settings.php
@@ -3,16 +3,24 @@
 $GLOBALS['TL_LANG']['tl_prosearch_settings']['settings_legend']= 'Einstellungen';
 $GLOBALS['TL_LANG']['tl_prosearch_settings']['license_legend']= 'Lizenzschlüssel';
 
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['searchIndexModules'][0] = 'Tabellen in die Suche aufnehmen';
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['searchIndexModules'][1] = 'Bitte wählen Sie aus, welche Tabellen in die Suche aufgenommen werden sollen.';
-
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['createIndex'][0] = 'Suche Aufbauen';
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['createIndex'][1] = '<strong>Bitte zuerst auf "Speichern" Klicken und danach auf "Aufbauen"</strong>. Warten Sie bitte bis alle Balken grün geworden sind. Dieser Vorgang kann einige Minuten dauern.';
-
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['prosearchLicense'][0] = 'Lizenzschlüssel eingeben';
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['prosearchLicense'][1] = 'Lizenzschlüssel <a href="#" target="_blank"><strong>kaufen</strong></a>';
-
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['addDescriptionToSearchContent'][0] = 'Texte in die Suche aufnehmen';
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['addDescriptionToSearchContent'][1] = 'Diese Option kann die Suche verlangsamen, dafür werden Text Spalten indiziert.';
-
+$GLOBALS['TL_LANG']['tl_prosearch_settings']['searchIndexModules'] = [
+    'Tabellen in die Suche aufnehmen',
+    'Bitte wählen Sie aus, welche Tabellen in die Suche aufgenommen werden sollen.'
+];
+$GLOBALS['TL_LANG']['tl_prosearch_settings']['createIndex'] = [
+    'Suche Aufbauen',
+    '<span style="color:red;">Bitte zuerst auf "Speichern" Klicken und danach auf "Aufbauen"</span>. Warten Sie bitte bis alle Balken grün geworden sind. Dieser Vorgang kann einige Minuten dauern.'
+];
+$GLOBALS['TL_LANG']['tl_prosearch_settings']['prosearchLicense'] = [
+    'Lizenzschlüssel eingeben',
+    'Lizenzschlüssel <a href="#" target="_blank"><strong>kaufen</strong></a>'
+];
+$GLOBALS['TL_LANG']['tl_prosearch_settings']['preventOpenSearchListAsPopup'] = [
+    'Links im Ergebnisfenster nicht als Popup öffnen',
+    'Standardmäßig werden die Links aus der Ergebnisliste bei Klick in einem Popup-Window geöffnet. Wird diese Option aktiviert, dann wird der Link in der Standard-Edit-Ansicht geöffnet.'
+];
+$GLOBALS['TL_LANG']['tl_prosearch_settings']['addDescriptionToSearchContent'] = [
+    'Texte in die Suche aufnehmen',
+    'Diese Option kann die Suche verlangsamen, dafür werden Text Spalten indiziert.'
+];
 $GLOBALS['TL_LANG']['tl_prosearch_settings']['invalidKey'] = 'Ihr Lizenzschlüssel ist ungültig';

--- a/languages/de/tl_user.php
+++ b/languages/de/tl_user.php
@@ -2,3 +2,7 @@
 
 $GLOBALS['TL_LANG']['tl_user']['prosearch_user_legend'] = 'ProSearch Benutzerdefiniert Einstellungen ';
 $GLOBALS['TL_LANG']['tl_user']['keyboard_shortcut'] = array('Tastaturkürzel', 'Definieren Sie Ihren Tastaturkürzel für "ProSearch öffnen" Befehl. Standard: alt+m.');
+$GLOBALS['TL_LANG']['tl_user']['preventOpenSearchListAsPopup'] = [
+    'Links im Ergebnisfenster nicht als Popup öffnen',
+    'Standardmäßig werden die Links aus der Ergebnisliste bei Klick in einem Popup-Window geöffnet. Wird diese Option aktiviert, dann wird der Link in der Standard-Edit-Ansicht geöffnet.'
+];

--- a/languages/de/tl_user.php
+++ b/languages/de/tl_user.php
@@ -1,6 +1,6 @@
 <?php
 
-$GLOBALS['TL_LANG']['tl_user']['prosearch_user_legend'] = 'ProSearch Benutzerdefiniert Einstellungen ';
+$GLOBALS['TL_LANG']['tl_user']['prosearch_user_legend'] = 'ProSearch - Benutzerdefinierte Einstellungen';
 $GLOBALS['TL_LANG']['tl_user']['keyboard_shortcut'] = array('Tastaturkürzel', 'Definieren Sie Ihren Tastaturkürzel für "ProSearch öffnen" Befehl. Standard: alt+m.');
 $GLOBALS['TL_LANG']['tl_user']['preventOpenSearchListAsPopup'] = [
     'Links im Ergebnisfenster nicht als Popup öffnen',

--- a/languages/en/tl_prosearch_settings.php
+++ b/languages/en/tl_prosearch_settings.php
@@ -15,10 +15,6 @@ $GLOBALS['TL_LANG']['tl_prosearch_settings']['prosearchLicense'] = [
     'Please enter valid license key',
     '<a href="#" target="_blank"><strong>Buy</strong></a> license key.'
 ];
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['preventOpenSearchListAsPopup'] = [
-    'Do not open links in the results list as a popup',
-    'By default, links from the results list will open in a popup window when clicked. If this option is enabled, then the link will be opened in the default Edit view.'
-];
 $GLOBALS['TL_LANG']['tl_prosearch_settings']['addDescriptionToSearchContent'] = [
     'Add text to Search',
     'This Option can slow down the search.'

--- a/languages/en/tl_prosearch_settings.php
+++ b/languages/en/tl_prosearch_settings.php
@@ -3,16 +3,24 @@
 $GLOBALS['TL_LANG']['tl_prosearch_settings']['settings_legend']= 'Settings';
 $GLOBALS['TL_LANG']['tl_prosearch_settings']['license_legend']= 'License key';
 
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['searchIndexModules'][0] = 'Select tables';
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['searchIndexModules'][1] = 'Please select which tables you want to include in the search.';
-
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['createIndex'][0] = 'Start indexing';
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['createIndex'][1] = 'Please wait until all beams are green.';
-
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['prosearchLicense'][0] = 'Please enter valid license key';
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['prosearchLicense'][1] = '<a href="#" target="_blank"><strong>Buy</strong></a> license key.';
-
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['addDescriptionToSearchContent'][0] = 'Add text to Search';
-$GLOBALS['TL_LANG']['tl_prosearch_settings']['addDescriptionToSearchContent'][1] = 'This Option can slow down the search.';
-
+$GLOBALS['TL_LANG']['tl_prosearch_settings']['searchIndexModules'] = [
+    'Select tables',
+    'Please select which tables you want to include in the search.'
+];
+$GLOBALS['TL_LANG']['tl_prosearch_settings']['createIndex'] = [
+    'Start indexing',
+    '<span style="color:red;">Please click "Save" first and then "Build"</span>. Please wait until all bars have turned green. This process may take a few minutes.'
+];
+$GLOBALS['TL_LANG']['tl_prosearch_settings']['prosearchLicense'] = [
+    'Please enter valid license key',
+    '<a href="#" target="_blank"><strong>Buy</strong></a> license key.'
+];
+$GLOBALS['TL_LANG']['tl_prosearch_settings']['preventOpenSearchListAsPopup'] = [
+    'Do not open links in the results list as a popup',
+    'By default, links from the results list will open in a popup window when clicked. If this option is enabled, then the link will be opened in the default Edit view.'
+];
+$GLOBALS['TL_LANG']['tl_prosearch_settings']['addDescriptionToSearchContent'] = [
+    'Add text to Search',
+    'This Option can slow down the search.'
+];
 $GLOBALS['TL_LANG']['tl_prosearch_settings']['invalidKey'] = 'Your license key is invalid.';

--- a/languages/en/tl_user.php
+++ b/languages/en/tl_user.php
@@ -2,3 +2,7 @@
 
 $GLOBALS['TL_LANG']['tl_user']['prosearch_user_legend'] = 'ProSearch User Settings ';
 $GLOBALS['TL_LANG']['tl_user']['keyboard_shortcut'] = array('Shortcut', 'Define your custom shortcut for "start proSearch" command. Default: alt+m.');
+$GLOBALS['TL_LANG']['tl_user']['preventOpenSearchListAsPopup'] = [
+    'Do not open links in the results list as a popup',
+    'By default, links from the results list will open in a popup window when clicked. If this option is enabled, then the link will be opened in the default Edit view.'
+];

--- a/src/Resources/contao/classes/InitializeProSearch.php
+++ b/src/Resources/contao/classes/InitializeProSearch.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * Prosearch bundle for Contao Open Source CMS
  *
  * @package    prosearch
+ * @license    ProSearch is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
  * @author     Alexander Naumov
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Resources/contao/classes/ProSearch.php
+++ b/src/Resources/contao/classes/ProSearch.php
@@ -265,7 +265,6 @@ class ProSearch extends ProSearchDataContainer
      */
     public function setCoreModules()
     {
-
         foreach ($this->modules as $k => $module) {
 
             $label = $GLOBALS['TL_LANG']['MOD'][$k];
@@ -282,7 +281,6 @@ class ProSearch extends ProSearchDataContainer
      */
     public function deleteModulesFromIndex()
     {
-
         $activeModules = deserialize(Config::get('searchIndexModules')) ? deserialize(Config::get('searchIndexModules')) : array();
         $coreModulesArr = Helper::pluckModules($this->coreModules);
         $toDeleteArr = array_diff($coreModulesArr, $activeModules);

--- a/src/Resources/contao/classes/ProSearchDataContainer.php
+++ b/src/Resources/contao/classes/ProSearchDataContainer.php
@@ -87,8 +87,8 @@ class ProSearchDataContainer extends DataContainer
             $titleUtf8  = mb_convert_encoding($title, 'UTF-8');
             $shortcut   = strtoupper($arrRow['shortcut']);
             $icon       = $arrRow['icon'];
-            $href       = $this->addToSearchUrl($arrRow, $queryStr) . (!$configPopup ? '&popup=1' : '');
-            $onclick    = (!$configPopup ? "onclick=\"GZM.openModalIframe({'width':960,'title':'$titleUtf8','url':this.href});return false\"" : '');
+            $href       = $this->addToSearchUrl($arrRow, $queryStr) . (!$configPopup ? '&popup=1&nb=1' : '');
+            $onclick    = (!$configPopup ? "onclick=\"Backend.openModalIframe({'width':960,'title':'$titleUtf8','url':this.href});return false\"" : '');
 
             // create the list item for the result window
             $listItem = <<<HTML
@@ -202,8 +202,8 @@ HTML;
             $icon = 'show.gif';
             $arrRow['dynTable'] = null; // reset dyntable if not needed
             $attributes = ($operations['show']['attributes'] != '') ? ' ' . ltrim(sprintf($operations['show']['attributes'], $id, $id)) : '';
-            $queryStr = $href.$id.$table.'&amp;popup=1';
-            $return .= '<a href="'.$this->addToSearchUrl($arrRow, $queryStr).'" tabindex="1" onclick="GZM.openModalIframe({\'width\':768,\'title\':\''.specialchars(str_replace("'", "\\'", sprintf($arrRow['title'], $arrRow['docId']))).'\',\'url\':this.href});return false"'.$attributes.'>'.Image::getHtml($icon).'</a> ';
+            $queryStr = $href.$id.$table.'&amp;popup=1&amp;nb=1';
+            $return .= '<a href="'.$this->addToSearchUrl($arrRow, $queryStr).'" tabindex="1" onclick="Backend.openModalIframe({\'width\':768,\'title\':\''.specialchars(str_replace("'", "\\'", sprintf($arrRow['title'], $arrRow['docId']))).'\',\'url\':this.href});return false"'.$attributes.'>'.Image::getHtml($icon).'</a> ';
         }
 
         if( $operations['show'] && $arrRow['dca'] == 'tl_files' )
@@ -212,7 +212,7 @@ HTML;
             $icon = 'show.gif';
             $arrRow['dynTable'] = null; // reset dyntable if not needed
             //$attributes = ($operations['show']['attributes'] != '') ? ' ' . ltrim(sprintf($operations['show']['attributes'], $id, $id)) : '';
-            $return .= '<a href="'.$href.'" tabindex="1" onclick="GZM.openModalIframe({\'width\':768,\'title\':\''.str_replace("'", "\\'", specialchars($arrRow['title'], false, true)).'\',\'url\':this.href,\'height\':500});return false" >'.Image::getHtml($icon).'</a>';
+            $return .= '<a href="'.$href.'" tabindex="1" onclick="Backend.openModalIframe({\'width\':768,\'title\':\''.str_replace("'", "\\'", specialchars($arrRow['title'], false, true)).'\',\'url\':this.href,\'height\':500});return false" >'.Image::getHtml($icon).'</a>';
         }
 
         $return .= '</div>';

--- a/src/Resources/contao/classes/ProSearchDataContainer.php
+++ b/src/Resources/contao/classes/ProSearchDataContainer.php
@@ -81,7 +81,8 @@ class ProSearchDataContainer extends DataContainer
             $title = strlen($arrRow['title']) > 100 ? substr($arrRow['title'],0,100).'…' : $arrRow['title'];
             $arrRow['dynTable'] = null; // reset dyntable if not needed
 
-            $return .= '<div class="title"><span class="icon" title="'.strtoupper($arrRow['shortcut']).'">'.$arrRow['icon'].'</span><a href="'.$this->addToSearchUrl($arrRow, $queryStr).'&popup=1" class="search-result" tabindex="1" onclick="Backend.openModalIframe({\'width\':960,\'title\':\''.$arrRow['title'].'\',\'url\':this.href});return false"><span>'.mb_convert_encoding($title, 'UTF-8').'</span> <span class="info">'.$tagsStr.'</span></a></div>';
+            #$return .= '<div class="title"><span class="icon" title="'.strtoupper($arrRow['shortcut']).'">'.$arrRow['icon'].'</span><a href="'.$this->addToSearchUrl($arrRow, $queryStr).'&popup=1" class="search-result" tabindex="1" onclick="Backend.openModalIframe({\'width\':960,\'title\':\''.$arrRow['title'].'\',\'url\':this.href});return false"><span>'.mb_convert_encoding($title, 'UTF-8').'</span> <span class="info">'.$tagsStr.'</span></a></div>';
+            $return .= '<div class="title"><span class="icon" title="'.strtoupper($arrRow['shortcut']).'">'.$arrRow['icon'].'</span><a href="'.$this->addToSearchUrl($arrRow, $queryStr).'" class="search-result" tabindex="1"><span>'.mb_convert_encoding($title, 'UTF-8').'</span> <span class="info">'.$tagsStr.'</span></a></div>';
         }
 
         $return .= '<div class="operations">';

--- a/src/Resources/contao/classes/ProSearchDataContainer.php
+++ b/src/Resources/contao/classes/ProSearchDataContainer.php
@@ -2,7 +2,7 @@
 
 namespace ProSearch;
 
-use Contao\Config;
+use Contao\BackendUser;
 use Contao\DataContainer;
 use Contao\Image;
 
@@ -37,7 +37,7 @@ class ProSearchDataContainer extends DataContainer
     public function createButtons($arrRow)
     {
         $strTable = $arrRow['dca'];
-		$this->loadDataContainer($strTable);
+        $this->loadDataContainer($strTable);
 
         if (empty($GLOBALS['TL_DCA'][$strTable]['list']['operations']))
         {
@@ -47,7 +47,7 @@ class ProSearchDataContainer extends DataContainer
         $return = '';
 
         $operations = $GLOBALS['TL_DCA'][$strTable]['list']['operations'];
-		$mode = $GLOBALS['TL_DCA'][$strTable]['list']['sorting']['mode'];
+        $mode = $GLOBALS['TL_DCA'][$strTable]['list']['sorting']['mode'];
 
         $id = specialchars(rawurldecode($arrRow['docId']));
         $id = $id ? '&amp;id='.$id : '';
@@ -78,7 +78,9 @@ class ProSearchDataContainer extends DataContainer
             }
 
             // get the config switch
-            $configPopup = (bool)Config::get('preventOpenSearchListAsPopup');
+            $objUser = BackendUser::getInstance();
+            $configPopup = (bool)$objUser->preventOpenSearchListAsPopup;
+
             // reset dyntable if not needed
             $arrRow['dynTable'] = null;
 
@@ -110,55 +112,55 @@ HTML;
         
         if( is_array($ctableArr) && !empty($ctableArr) && $mode != 5 && $fmTable != 'fm')
         {
-	        
-	        $href = '';
-	        $icon = '';
-	        $ptable = '';
-	        $arrRow['dynTable'] = null;
-	        
-	        foreach($ctableArr as $ctable)
-	        {
-		       $href = '&amp;table='.$ctable.''; 
-		       $icon = 'edit.gif';
-		       $ptable = '';
-		       
-	        }
-	        
-	        $queryStr = $href.$id.$ptable;
-	        $return .= '<a href="'.$this->addToSearchUrl($arrRow, $queryStr).'" tabindex="1">'.Image::getHtml($icon,$arrRow['title']).'</a>';
+            
+            $href = '';
+            $icon = '';
+            $ptable = '';
+            $arrRow['dynTable'] = null;
+            
+            foreach($ctableArr as $ctable)
+            {
+               $href = '&amp;table='.$ctable.''; 
+               $icon = 'edit.gif';
+               $ptable = '';
+               
+            }
+            
+            $queryStr = $href.$id.$ptable;
+            $return .= '<a href="'.$this->addToSearchUrl($arrRow, $queryStr).'" tabindex="1">'.Image::getHtml($icon,$arrRow['title']).'</a>';
 
         }
-		
-		// go to ietm
+        
+        // go to ietm
         if( $operations['editheader'] || $operations['edit'] )
         {
 
             $href = 'act=edit';
             $icon = 'header.gif';
-			$ptable = $table;
+            $ptable = $table;
             $arrRow['dynTable'] = null; // reset dyntable if not needed
             $queryStr = $href.$id.$ptable;
             $return .= '<a href="'.$this->addToSearchUrl($arrRow, $queryStr).'" tabindex="1">'.Image::getHtml($icon,$arrRow['title']).'</a>';
         }
-		
-		if( $fmTable == 'fm' )
-		{
-			// list view
-			$href = '&amp;table=tl_content';
-			$fmType = '&view=list';	
-			$icon = $GLOBALS['PS_PUBLIC_PATH'].'images/page.png';
-			$queryStr = $href.$fmType.$id;
-			$arrRow['dynTable'] = null;
-	        $return .= '<a href="'.$this->addToSearchUrl($arrRow, $queryStr).'" tabindex="1">'.Image::getHtml($icon,$arrRow['title']).'</a>';
-	        
-	        //detailview
-			$icon = $GLOBALS['PS_PUBLIC_PATH'].'images/detail.png';
-			$fmType = '&view=detail';	
-			$queryStr = $href.$fmType.$id;
-	        $return .= '<a href="'.$this->addToSearchUrl($arrRow, $queryStr).'" tabindex="1">'.Image::getHtml($icon,$arrRow['title']).'</a>';
+        
+        if( $fmTable == 'fm' )
+        {
+            // list view
+            $href = '&amp;table=tl_content';
+            $fmType = '&view=list';    
+            $icon = $GLOBALS['PS_PUBLIC_PATH'].'images/page.png';
+            $queryStr = $href.$fmType.$id;
+            $arrRow['dynTable'] = null;
+            $return .= '<a href="'.$this->addToSearchUrl($arrRow, $queryStr).'" tabindex="1">'.Image::getHtml($icon,$arrRow['title']).'</a>';
+            
+            //detailview
+            $icon = $GLOBALS['PS_PUBLIC_PATH'].'images/detail.png';
+            $fmType = '&view=detail';    
+            $queryStr = $href.$fmType.$id;
+            $return .= '<a href="'.$this->addToSearchUrl($arrRow, $queryStr).'" tabindex="1">'.Image::getHtml($icon,$arrRow['title']).'</a>';
 
-		}
-		
+        }
+        
         if($arrRow['doTable'] == 'page')
         {
 
@@ -260,12 +262,12 @@ HTML;
             {
                 unset($queries[$k]);
             }
-			
-			if($key == 'searchQuery')
+            
+            if($key == 'searchQuery')
             {
                 unset($queries[$k]);
             }
-			
+            
             if (in_array($key, $arrUnset) || preg_match('/(^|&(amp;)?)' . preg_quote($key, '/') . '=/i', $strRequest))
             {
                 unset($queries[$k]);

--- a/src/Resources/contao/classes/UserSettings.php
+++ b/src/Resources/contao/classes/UserSettings.php
@@ -1,32 +1,43 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * Prosearch bundle for Contao Open Source CMS
+ *
+ * @package    prosearch
+ * @license    ProSearch is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+ * @author     Alexander Naumov
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace ProSearch;
 
-class UserSettings {
+use Contao\BackendUser;
 
+class UserSettings
+{
     private $blnInitialized = false;
     private $strPlaceholder = '<!-- ### %PROSEARCH_SCRIPT_TAG% ### -->';
 
-
-    public function initializeSettings( $strContent, $strTemplate ) {
-
-        if ( $strTemplate == 'be_main' && !$this->blnInitialized ) {
-
-            $objUser = \BackendUser::getInstance();
+    public function initializeSettings($strContent, $strTemplate)
+    {
+        if ('be_main' === $strTemplate && !$this->blnInitialized) {
+            $objUser = BackendUser::getInstance();
 
             $arrSettings = [
-
                 'enable' => true,
                 'id' => $objUser->id,
                 'shortcut' => $objUser->keyboard_shortcut ? $objUser->keyboard_shortcut : 'alt+m',
             ];
 
-            if ( isset( $objUser->modules ) && !empty( $objUser->modules ) && is_array( $objUser->modules ) ) {
-
-                $arrSettings['enable'] = in_array( 'prosearch_settings' , $objUser->modules );
+            if (isset($objUser->modules) && !empty($objUser->modules) && \is_array($objUser->modules)) {
+                $arrSettings['enable'] = \in_array('prosearch_settings', $objUser->modules, true);
             }
 
-            $strContent = str_replace( $this->strPlaceholder, '<script>var UserSettings = ' . json_encode( $arrSettings ) . ';</script>',  $strContent );
+            $strContent = str_replace($this->strPlaceholder, '<script>var UserSettings = '.json_encode($arrSettings).';</script>', $strContent);
             $this->blnInitialized = true;
         }
 

--- a/src/Resources/contao/widgets/AjaxSearchIndex.php
+++ b/src/Resources/contao/widgets/AjaxSearchIndex.php
@@ -1,14 +1,28 @@
-<?php namespace ProSearch;
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Prosearch bundle for Contao Open Source CMS
+ *
+ * @package    prosearch
+ * @license    ProSearch is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+ * @author     Alexander Naumov
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ProSearch;
 
 use Contao\Config;
 use Contao\Widget;
 
 /**
- * Class AjaxSearchIndex
+ * Class AjaxSearchIndex.
  */
 class AjaxSearchIndex extends Widget
 {
-
     /**
      * @var string
      */
@@ -34,8 +48,6 @@ class AjaxSearchIndex extends Widget
         // load js
         $GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/prosearch/assets/JsIndex.js|static';
 
-        return  '<div class="index_list"><ul class="ul"></ul></div><div class="ajaxSearchIndex"><a class="tl_submit" style="margin-bottom: 5px; margin-top: 5px" onclick="Backend.getScrollOffset();return AjaxRequest.ajaxSearchIndex()">'.$bStr.'</a></div>';
-
+        return '<div class="index_list"><ul class="ul"></ul></div><div class="ajaxSearchIndex"><a class="tl_submit" style="margin-bottom: 5px; margin-top: 5px" onclick="Backend.getScrollOffset();return AjaxRequest.ajaxSearchIndex()">'.$bStr.'</a></div>';
     }
-
 }

--- a/src/Resources/contao/widgets/TagTextField.php
+++ b/src/Resources/contao/widgets/TagTextField.php
@@ -1,33 +1,47 @@
-<?php namespace ProSearch;
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Prosearch bundle for Contao Open Source CMS
+ *
+ * @package    prosearch
+ * @license    ProSearch is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+ * @author     Alexander Naumov
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ProSearch;
+
+use Contao\Database;
+use Contao\Environment;
+use Contao\Input;
 
 class TagTextField extends \Widget
 {
-
     protected $blnSubmitInput = true;
-
 
     protected $strTemplate = 'be_widget';
 
-
-    public function validator($varInput) {
-
+    public function validator($varInput)
+    {
         return parent::validator($varInput);
     }
 
-    public function generate() {
-
-        $strTags = \Input::get('ps_tags');
-        $strActionTag = \Input::get('actionPSTag');
-        $strRequestUri = \Environment::get('requestUri');
+    public function generate()
+    {
+        $strTags = Input::get('ps_tags');
+        $strActionTag = Input::get('actionPSTag');
+        $strRequestUri = Environment::get('requestUri');
         $strRequestUri = $this->removeRequestTokenFromUri($strRequestUri);
 
-        if ( $strActionTag && $strActionTag == 'updateTags' ) {
-
+        if ($strActionTag && 'updateTags' === $strActionTag) {
             $this->updateTags($strTags);
         }
 
-        if ( $strActionTag && $strActionTag == 'removeTags' ) {
-
+        if ($strActionTag && 'removeTags' === $strActionTag) {
             $this->removeTags($strTags);
         }
 
@@ -35,20 +49,19 @@ class TagTextField extends \Widget
         $GLOBALS['TL_CSS'][] = 'system/modules/prosearch/assets/css/mootagify-bootstrap.css|static';
         $GLOBALS['TL_CSS'][] = 'system/modules/prosearch/assets/css/mootagify.css|static';
 
-        $objTags = \Database::getInstance()->prepare('SELECT * FROM tl_prosearch_tags')->execute();
+        $objTags = Database::getInstance()->prepare('SELECT * FROM tl_prosearch_tags')->execute();
         $arrOptions = [''];
 
         while ($objTags->next()) {
-
             $arrOptions[] = $objTags->tagname;
         }
 
         $script = sprintf(
             '<script>'
-            . 'window.addEvent("domready", function(){
+            .'window.addEvent("domready", function(){
                 var tagify = new mooTagify(document.id("tagWrap_%s"), null ,{
                     autoSuggest: true,
-                    availableOptions: '. json_encode($arrOptions) .'
+                    availableOptions: '.json_encode($arrOptions).'
                 });
                 tagify.addEvent("tagsUpdate", function(){
                     var tags = tagify.getTags();
@@ -61,9 +74,16 @@ class TagTextField extends \Widget
                     document.id("ctrl_%s").set("value", tags.join());
                     new Request({url: "%s&actionPSTag=removeTags"}).get({ "ps_tags": deleted, "rt": Contao.request_token });
                 });
-            });' . '</script>', $this->strId, $this->strId, $strRequestUri, $this->strId, $strRequestUri);
+            });'.'</script>',
+            $this->strId,
+            $this->strId,
+            $strRequestUri,
+            $this->strId,
+            $strRequestUri
+        );
 
-        return sprintf('<input type="hidden" id="ctrl_%s" name="%s" value="%s"><div id="tagWrap_%s" class="hide"> <div class="tag-wrapper"></div> <div class="tag-input"> <input type="text" id="listTags" class="tl_text" name="listTags" value="%s" placeholder="%s"> </div> <div class="clear"></div></div>' . $script . '',
+        return sprintf(
+            '<input type="hidden" id="ctrl_%s" name="%s" value="%s"><div id="tagWrap_%s" class="hide"> <div class="tag-wrapper"></div> <div class="tag-input"> <input type="text" id="listTags" class="tl_text" name="listTags" value="%s" placeholder="%s"> </div> <div class="clear"></div></div>'.$script.'',
             $this->strId,
             $this->strName,
             specialchars($this->varValue),
@@ -73,79 +93,70 @@ class TagTextField extends \Widget
         );
     }
 
-    private function removeRequestTokenFromUri( $strRequest ) {
+    public function updateTags($arrTags): void
+    {
+        if (!\is_array($arrTags)) {
+            $this->sendRes();
+        }
 
+        $arrValues = $arrTags ?: [];
+        $arrTagsExist = [];
+
+        $tagsDB = Database::getInstance()->prepare('SELECT * FROM tl_prosearch_tags')->execute();
+
+        while ($tagsDB->next()) {
+            $arrTagsExist[] = $tagsDB->tagname;
+        }
+
+        foreach ($arrValues as $strTagName) {
+            if (!\in_array($strTagName, $arrTagsExist, true)) {
+                Database::getInstance()->prepare('INSERT INTO tl_prosearch_tags (tstamp,tagname) VALUES (?,?)')->execute(time(), $strTagName);
+            }
+        }
+
+        $this->sendRes();
+    }
+
+    public function removeTags($strTag): void
+    {
+        if (!\is_string($strTag)) {
+            $this->sendRes();
+        }
+
+        $strTagName = $strTag ?: '';
+        $existInSearchDB = Database::getInstance()->prepare('SELECT * FROM tl_prosearch_data WHERE tags LIKE ? ORDER BY tstamp DESC LIMIT 10')->execute("%$strTagName%");
+
+        if ($existInSearchDB->count() > 1) {
+            $this->sendRes();
+        }
+
+        Database::getInstance()->prepare('DELETE FROM tl_prosearch_tags WHERE tagname = ?')->execute($strTagName);
+
+        $this->sendRes();
+    }
+
+    public function sendRes(): void
+    {
+        header('Content-type: application/json');
+
+        echo json_encode(['state' => '200']);
+
+        exit;
+    }
+
+    private function removeRequestTokenFromUri($strRequest)
+    {
         $arrRequestUri = explode('&', $strRequest);
         $arrTemps = [];
 
-        foreach( $arrRequestUri as $strUriPart ) {
-
-            if ( substr( $strUriPart, 0, 2 ) == 'rt' ) {
+        foreach ($arrRequestUri as $strUriPart) {
+            if ('rt' === substr($strUriPart, 0, 2)) {
                 continue;
             }
 
             $arrTemps[] = $strUriPart;
         }
 
-        return implode( '&', $arrTemps );
+        return implode('&', $arrTemps);
     }
-
-    public function updateTags( $arrTags ) {
-
-        if ( !is_array( $arrTags ) ) {
-
-            $this->sendRes();
-        }
-
-        $arrValues = $arrTags ? $arrTags : [];
-        $arrTagsExist = array();
-
-        $tagsDB = \Database::getInstance()->prepare('SELECT * FROM tl_prosearch_tags')->execute();
-
-        while ( $tagsDB->next() ) {
-
-            $arrTagsExist[] = $tagsDB->tagname;
-        }
-
-        foreach ( $arrValues as $strTagName ) {
-
-            if ( !in_array( $strTagName, $arrTagsExist ) ) {
-
-                \Database::getInstance()->prepare( 'INSERT INTO tl_prosearch_tags (tstamp,tagname) VALUES (?,?)')->execute( time(), $strTagName );
-            }
-        }
-
-        $this->sendRes();
-    }
-
-
-    public function removeTags( $strTag ) {
-
-        if ( !is_string( $strTag ) ) {
-
-            $this->sendRes();
-        }
-
-        $strTagName = $strTag ? $strTag : '';
-        $existInSearchDB = \Database::getInstance()->prepare("SELECT * FROM tl_prosearch_data WHERE tags LIKE ? ORDER BY tstamp DESC LIMIT 10")->execute( "%$strTagName%" );
-
-        if ($existInSearchDB->count() > 1) {
-            $this->sendRes();
-        }
-
-        \Database::getInstance()->prepare('DELETE FROM tl_prosearch_tags WHERE tagname = ?')->execute( $strTagName );
-
-        $this->sendRes();
-    }
-
-
-    public function sendRes() {
-
-        header('Content-type: application/json');
-
-        echo json_encode( ['state' => '200' ] );
-
-        exit;
-    }
-
 }


### PR DESCRIPTION
This PR modiefies the link in the prosearch result window. It removes a <span> tag, the Backend.modal() function and the popup=1 attribute to prevent false operations after opening a modal window.